### PR TITLE
Predefined reactive power

### DIFF
--- a/examples/own_topology.jl
+++ b/examples/own_topology.jl
@@ -19,6 +19,9 @@ own_graph = generate_graph(RandomPowerGrid(num_nodes, [1, 1/5, 3/10, 1/3, 1/10, 
 # And sample random power set-points and assure power balance:
 P_vec = rand(seed, num_nodes) 
 P_vec .-= sum(P_vec) / (num_nodes)  
+Q_vec = zeros(num_nodes)
+nodes_load_flow = fill(:PVAlgebraic, num_nodes)
+nodes_load_flow[10] = :PQAlgebraic
 
 # Then we assign the typical number of cables to each transmission line and calculate the admittances and shunts.
 # Here we use the default algorithms given by the package but generating it another way is possible as well.
@@ -33,7 +36,7 @@ nodal_parameters = Dict(:τ_Q => 5.0, :K_P => 5, :K_Q => 5, :τ_P => 5.0)
 nodal_dynamics = [(1.0, get_DroopControlledInverterApprox, nodal_parameters)]
 
 # Then we generate the struct again but use multiple new optional arguments such as `P_vec` for the active power set-points and `embedded_graph` to hand over the topology:
-pg_struct = PGGeneration(num_nodes = num_nodes, cables_vec = cables_vec, nodal_dynamics = nodal_dynamics, P_vec = P_vec, embedded_graph = own_graph, coupling = :predefined, lines = :StaticLine, slack = true, edge_parameters = edge_parameters)
+pg_struct = PGGeneration(num_nodes = num_nodes, cables_vec = cables_vec, nodal_dynamics = nodal_dynamics, Q_vec = Q_vec, P_vec = P_vec, embedded_graph = own_graph, coupling = :predefined, lines = :StaticLine, slack = true, edge_parameters = edge_parameters, node_types_ancillary = nodes_load_flow)
 
 # Finally we generate the synthetic network:
 pg, op, pg_struct_new, rejections = generate_powergrid_dynamics(pg_struct)

--- a/src/operationpoint.jl
+++ b/src/operationpoint.jl
@@ -1,18 +1,27 @@
 """
-    get_ancillary_operationpoint(P_vec, V_vec, num_nodes, slack_idx, lines)
+    get_ancillary_operationpoint(P_vec, Q_vec, V_vec, node_types, slack_idx, lines)
 
 Get an Ancillary Power Grid with the same power flow on the lines as the full power grid.
 We use PV-Nodes to find the reactive power at the nodes with results in power grids where the voltage magnitude V is equal to the Reference voltage magnitude V_r.
 
-- `pg_struct`: Struct containing all data of the power grid
+- `P_vec`: Vector containing the nodal active powers
+- `Q_vec`: Vector containing the nodal reactive powers
+- `V_vec`: Vector containing the nodal voltage magnitudes
+- `node_types`: Vector congaing the different node type for the ancillary grid
+- `slack_idx`: Index of the slack bus in the ancillary grid
 - `lines`: Line dynamics of the power grid
 """
-function get_ancillary_operationpoint(P_vec, V_vec, num_nodes, slack_idx, lines)
+function get_ancillary_operationpoint(P_vec, Q_vec, V_vec, node_types, slack_idx, lines)
+    num_nodes = length(node_types)
     nodes = Array{Any}(undef, num_nodes)
 
     # Get Ancillary Power Grid
     for n in 1:num_nodes
-        nodes[n] = PVAlgebraic(P = P_vec[n], V = V_vec[n])
+        if node_types[n] == :PVAlgebraic
+            nodes[n] = PVAlgebraic(P = P_vec[n], V = V_vec[n])
+        elseif node_types[n] == :PQAlgebraic
+            nodes[n] = PQAlgebraic(P = P_vec[n], Q = Q_vec[n])
+        end
     end
     nodes[slack_idx] = SlackAlgebraic(U = complex(V_vec[slack_idx]))
     

--- a/src/pg_generation.jl
+++ b/src/pg_generation.jl
@@ -48,10 +48,7 @@ function generate_powergrid_dynamics(pg_struct::PGGeneration)
 
         pg_struct_updated.P_vec = op_ancillary[:, :p]
         pg_struct_updated.V_vec = op_ancillary[:, :v]
-
-        if typeof(pg_struct.Q_vec) == Vector{Nothing} 
-            pg_struct_updated.Q_vec = op_ancillary[:, :q] # Reactive Power of the ancillary power grid
-        end
+        pg_struct_updated.Q_vec = op_ancillary[:, :q] # Reactive Power of the ancillary power grid
 
         nodes = get_nodes(pg_struct_updated.P_vec, pg_struct_updated.Q_vec, pg_struct_updated.V_vec, pg_struct_updated.slack, pg_struct_updated.slack_idx, pg_struct_updated.nodal_dynamics)
         pg = PowerGrid(nodes, lines)

--- a/src/pg_generation.jl
+++ b/src/pg_generation.jl
@@ -44,7 +44,7 @@ function generate_powergrid_dynamics(pg_struct::PGGeneration)
             lines = get_lines(pg_struct_updated) # Line dynamics
         end
 
-        op_ancillary = get_ancillary_operationpoint(pg_struct_updated.P_vec, pg_struct_updated.V_vec, pg_struct_updated.num_nodes, pg_struct_updated.slack_idx, lines)
+        op_ancillary = get_ancillary_operationpoint(pg_struct_updated.P_vec, pg_struct_updated.Q_vec, pg_struct_updated.V_vec, pg_struct_updated.node_types_ancillary, pg_struct_updated.slack_idx, lines)
 
         pg_struct_updated.P_vec = op_ancillary[:, :p]
         pg_struct_updated.V_vec = op_ancillary[:, :v]

--- a/src/pg_struct.jl
+++ b/src/pg_struct.jl
@@ -57,7 +57,14 @@ function validate_struct(pg_struct::PGGeneration)
         error("This option for the power distribution is not supported. Please use power_distribution = :Bimodal or :Plus_Minus_1 instead.")
     end
 
-    if pg_struct.node_types_ancillary != :PVAlgebraic && pg_struct.node_types_ancillary != :PQAlgebraic
+    nodes_load_flow = copy(pg_struct.node_types_ancillary)
+    pq_idx = findall(nodes_load_flow.== :PQAlgebraic)
+    deleteat!(nodes_load_flow, pq_idx)
+
+    pv_idx = findall(nodes_load_flow.== :PVAlgebraic)
+    deleteat!(nodes_load_flow, pv_idx)
+
+    if !isempty(nodes_load_flow)
         error("This node option for the load flow initialization is not supported. Please use either :PVAlgebraic or :PQAlgebraic.")
     end
 

--- a/src/pg_struct.jl
+++ b/src/pg_struct.jl
@@ -16,6 +16,7 @@
     num_nodes::Int64; @assert num_nodes > 0.0 "Number of nodes can not be negative."
     nodal_dynamics::Vector{Tuple{Float64, Function, Any}}
     @assert sum(map(nd -> nodal_dynamics[nd][1], 1:length(nodal_dynamics))) == 1.0 "The sum of all nodal share has to equal 1.0!"
+    node_types_ancillary = fill(:PVAlgebraic, num_nodes); @assert length(node_types_ancillary) == num_nodes "Give a type of node for the load flow initialization for each node."
 
     # Power 
     power_distribution::Symbol = :Bimodal;
@@ -54,6 +55,10 @@ function validate_struct(pg_struct::PGGeneration)
 
     if pg_struct.power_distribution != :Bimodal && pg_struct.power_distribution != :Plus_Minus_1
         error("This option for the power distribution is not supported. Please use power_distribution = :Bimodal or :Plus_Minus_1 instead.")
+    end
+
+    if pg_struct.node_types_ancillary != :PVAlgebraic && pg_struct.node_types_ancillary != :PQAlgebraic
+        error("This node option for the load flow initialization is not supported. Please use either :PVAlgebraic or :PQAlgebraic.")
     end
 
     if pg_struct.power_distribution == :Plus_Minus_1

--- a/src/probabilistic_capacity_expansion.jl
+++ b/src/probabilistic_capacity_expansion.jl
@@ -15,8 +15,7 @@ function probabilistic_capacity_expansion(pg_struct::PGGeneration, dist_load, di
     # Run over all scenarios
     for k in 1:pg_struct.num_tries
         P_set_prob = dist_load(dist_args...) # Sample new set points from the Distributions
-
-        op_prob = get_ancillary_operationpoint(P_set_prob, pg_struct.V_vec, num_nodes, pg_struct.slack_idx, lines)
+        op_prob = get_ancillary_operationpoint(P_set_prob, pg_struct.Q_vec, pg_struct.V_vec, pg_struct.node_types_ancillary, pg_struct.slack_idx, lines)
         save_network, save_flow, _, _ = validate_power_flow_on_lines(op_prob, pg_struct.lines)
 
         if save_network == false 


### PR DESCRIPTION
Allow for a vector of predefined reactive powers. These are used for each node where in the load flow initialization :PQAlgebraic is used instead of :PVAlgebraic.